### PR TITLE
カリキュラム８−６終了

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -36,4 +36,9 @@ class PostController extends Controller
         $post->fill($input_post)->save();
         return redirect('/posts/' .$post->id);
     }
+    public function delete(Post $post)
+    {
+        $post->delete();
+        return redirect('/');
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -4,10 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
     use HasFactory;
+    use SoftDeletes;
     
     protected $fillable = [
         'title',

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -16,9 +16,23 @@
             <div class='post'>
                 <a href="/posts/{{ $post->id}}"><h2 class='title'>{{ $post->title }}</h2></a>
                 <p class='body'>{{ $post->body }}</p>
+                <form action="/posts/{{$post->id}}" id="form_{{$post->id}}" method="post">
+                    @csrf
+                    @method('DELETE')
+                <button type="button" onclick="deletePost({{$post->id}})">delete</button>
+                </form>
             </div>
             @endforeach
         </div>
         <div class='paginate'>{{ $posts->links()}}</div>
+        <script>
+            function deletePost(id){
+                'use strict'
+                
+                if(confirm('削除すると復元されません。\n本当に削除しますか？')){//confirm関数は引数の場所に書いた文字列がポップアップとして表示される関数
+                    document.getElementById(`form_${id}`).submit();    
+                }
+            }
+        </script>
     </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,3 +20,4 @@ Route::get('/posts/{post}',[PostController::class, 'show']);
 Route::post('/posts',[PostController::class, 'store']);
 Route::get('/posts/{post}/edit',[PostController::class, 'edit']);
 Route::put('/posts/{post}',[PostController::class, 'update']);
+Route::delete('/posts/{post}',[PostController::class, 'delete']);


### PR DESCRIPTION
投稿一覧画面に削除ボタンを実装する。同時に削除を押したときに削除するかどうかの確認を表示するポップアウトをJSで実装する。
最後に論理削除にするためにSoftDeletesを追加した